### PR TITLE
feat: use google brotli repository and bump nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,9 @@ FROM alpine:3.10
 
 LABEL maintainer="NGINX Docker Maintainers <docker-maint@nginx.com> - Modified by: blackholegalaxy"
 
-ENV NGINX_VERSION 1.17.3
-ENV NGINX_BROTLI_REPOSITORY https://github.com/eustas/ngx_brotli.git
-ENV NGINX_BROTLI_COMMIT 0e58b80a317709a9956316180eb48c3ec56c1d59 
+ENV NGINX_VERSION 1.17.4
+ENV NGINX_BROTLI_REPOSITORY https://github.com/google/ngx_brotli.git
+ENV NGINX_BROTLI_COMMIT e505dce68acc190cc5a1e780a3b0275e39f160ca
 
 RUN GPG_KEYS=B0F4253373F8F6F510D42178520A9993A1C052F8 \
 	&& CONFIG="\


### PR DESCRIPTION
# Move repo
Since brotli is back on google repository, use google one instead of fork

# Bump
Update to nginx 1.17.4